### PR TITLE
Fix rSNBATWPL output to match rsnbatwpl-cli.js

### DIFF
--- a/langs/raisin-batwaffle.js
+++ b/langs/raisin-batwaffle.js
@@ -68,14 +68,14 @@ fetch('https://raw.githubusercontent.com/Radvylf/rSNBATWPL/main/rsnbatwpl.js').t
 })
 DSO.defineMode('raisin-batwaffle', async (code,input,args,output,debug) => {
     try {
-        let {prints, out} = await rsnbatwpl(code, input.split`\n`.map(v => {
+        let {sprints} = await rsnbatwpl(code, input.split`\n`.map(v => {
             try {
                 return JSON.parse(v)
             } catch {
                 return v
             }
         }), null, null, debug, true)
-        output(prints+'\n'+out)
+        output(sprints)
     } catch(ex) { 
         debug(ex)
     }


### PR DESCRIPTION
Fix rSNBATWPL output to match rsnbatwpl-cli.js when called with filename argument, see [here](https://github.com/Radvylf/rSNBATWPL/blob/6c26fc96/rsnbatwpl-cli.js#L126). See also [this issue](https://github.com/Radvylf/rSNBATWPL/issues/2). I will fix [this answer](https://codegolf.stackexchange.com/a/248721) accordingly.