### PR TITLE
Use `splitlines()` in Python loaders

### DIFF
--- a/langs/flax/loader.py
+++ b/langs/flax/loader.py
@@ -8,7 +8,7 @@ os.mkdir("flax")
 async def main():
     files = await fetch("/langs/flax/all.txt")
     files = await files.text()
-    for file in files.split('\n')[:-1]:
+    for file in files.splitlines():
         text = await fetch('https://raw.githubusercontent.com/pygamer0/flax/master/flax/' + file)
         text = await text.text()
         with open('flax/' + file, "w") as f:

--- a/langs/jelly-fork/loader.py
+++ b/langs/jelly-fork/loader.py
@@ -8,7 +8,7 @@ os.mkdir("jelly")
 async def main():
     files = await fetch("/langs/jelly/all.txt")
     files = await files.text()
-    for file in files.split('\n')[:-1]:
+    for file in files.splitlines():
         text = await fetch('https://raw.githubusercontent.com/cairdcoinheringaahing/jellylanguage/master/jelly/' + file)
         text = await text.text()
         with open('jelly/' + file, "w") as f:

--- a/langs/jelly/loader.py
+++ b/langs/jelly/loader.py
@@ -8,7 +8,7 @@ os.mkdir("jelly")
 async def main():
     files = await fetch("/langs/jelly/all.txt")
     files = await files.text()
-    for file in files.split('\n')[:-1]:
+    for file in files.splitlines():
         text = await fetch('https://raw.githubusercontent.com/DennisMitchell/jellylanguage/master/jelly/' + file)
         text = await text.text()
         with open('jelly/' + file, "w") as f:

--- a/langs/pip/loader.py
+++ b/langs/pip/loader.py
@@ -5,7 +5,7 @@ from js import fetch
 async def main():
     files = await fetch("/langs/pip/all.txt")
     files = await files.text()
-    for file in files.split('\n')[:-1]:
+    for file in files.splitlines():
         text = await fetch('https://raw.githubusercontent.com/dloscutoff/pip/master/' + file)
         text = await text.text()
         with open(file, "w") as f:


### PR DESCRIPTION
Two reasons to use `splitlines()` instead of `split('\n')`:

1. The code looks nicer.
2. `splitlines()` works correctly with Windows `\r\n` line separators.

(I was getting weird errors trying to run Pip on a local copy of DSO. It turned out that the loader was creating files like `pip.py\r`, and then it couldn't find `pip.py` to import from it.)