### PR TITLE
Better output handling for Pyodide

### DIFF
--- a/python-utils.js
+++ b/python-utils.js
@@ -1,20 +1,31 @@
 async function loadPyodide(){
-    await import('https://cdn.jsdelivr.net/pyodide/v0.19.0/full/pyodide.js')
+    await import('https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js')
     window.pythonInput = [];
     try {
         if (!window.pyodide) {
             DSO.startLoad();
             let time = Date.now()
+            let decoder = new TextDecoder();
             let pyodide = await loadPyodide({
-                indexURL: "https://cdn.jsdelivr.net/pyodide/v0.19.0/full/",
-                stdin: _ => pythonInput.shift() ?? eval('throw "out of input"'),
-                stdout: str => {
-                    if (str != 'Python initialization complete') {
-                        $('output').value += str + '\n';
-                    }
-                },
-                stderr: str => $('debug').value += str + '\n'
+                indexURL: "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/"
             })
+            pyodide.setStdin({
+                stdin: () => pythonInput.shift()
+                // Once pythonInput is empty, shift() returns undefined,
+                // which Pyodide treats as EOF
+            });
+            pyodide.setStdout({
+                write: buf => {
+                    $('output').value += decoder.decode(buf);
+                    return buf.length;
+                }
+            });
+            pyodide.setStderr({
+                write: buf => {
+                    $('debug').value += decoder.decode(buf);
+                    return buf.length;
+                }
+            });
             console.log('python (pyodide) loaded in %d seconds', (Date.now() - time) / 1000)
             window.pyodide = pyodide
             DSO.endLoad();


### PR DESCRIPTION
- Used buffer-based "write" output handler for stdout and stderr rather than string-based "batched" handler
- Upgraded Pyodide version to 0.25.0
 
Pyodide's batched output handler doesn't work as expected when the output stream is flushed (see https://github.com/pyodide/pyodide/issues/4139). The write handler does. The version upgrade was necessary to get access to the `setStdin`, `setStdout`, and `setStderr` functions.