### PR TITLE
Fix several problems with Pip

### DIFF
--- a/langs/pip/all.txt
+++ b/langs/pip/all.txt
@@ -7,3 +7,4 @@ ptypes.py
 scanning.py
 tokens.py
 version.py
+Tao of Pip.txt

--- a/langs/pip/loader.py
+++ b/langs/pip/loader.py
@@ -11,5 +11,5 @@ async def main():
         with open(file, "w") as f:
             f.write(text)
     
-    global pip
-    from pip import pip
+    global runpip
+    from pip import run as runpip

--- a/langs/pip/pip.js
+++ b/langs/pip/pip.js
@@ -5,9 +5,9 @@ pyodide.runPythonAsync(await (await fetch('/langs/pip/loader.py')).text() + '\na
 .then (() => DSO.endLoad());
 
 DSO.defineMode("pip", async (code,input,args,output,debug) => {
-    let argstring = args + ' ' + input;
     try {
-        pyodide.globals.get('pip')(code, argstring)
+        window.pythonInput = input.split`\n`
+        pyodide.globals.get('pip')(code, args)
     } catch (e) {
         console.log(e)
         debug(e)

--- a/langs/pip/pip.js
+++ b/langs/pip/pip.js
@@ -7,7 +7,7 @@ pyodide.runPythonAsync(await (await fetch('/langs/pip/loader.py')).text() + '\na
 DSO.defineMode("pip", async (code,input,args,output,debug) => {
     try {
         window.pythonInput = input.split`\n`
-        pyodide.globals.get('pip')(code, args)
+        pyodide.globals.get('runpip')(code, args)
     } catch (e) {
         console.log(e)
         debug(e)

--- a/langs/pip/script.sh
+++ b/langs/pip/script.sh
@@ -2,5 +2,6 @@ git clone https://github.com/dloscutoff/pip.git
 cd pip
 #mv *.py ../
 ls *.py > ../all.txt
+ls 'Tao of Pip.txt' >> ../all.txt
 cd ../
 rm -rf pip


### PR DESCRIPTION
- Pip treats command-line arguments and stdin separately (and [both can be used](https://codegolf.stackexchange.com/a/207606/16766) in the same program), so the Arguments box should be used for arguments and the Input box should be used for stdin.
- Some changes to the Pip interpreter mean `run()` is now a better function for DSO to use to run Pip code than `pip()`. I imported it under the alias `runpip()` for maximum clarity.
- `all.txt` was missing a very important file. 😉 