### PR TITLE
Fix for Python-based languages when hosted on GitHub Pages

### DIFF
--- a/langs/flax/flax.js
+++ b/langs/flax/flax.js
@@ -3,7 +3,8 @@ await loadPyodide();
 
 pyodide.loadPackage(['mpmath', 'more-itertools'])
 
-pyodide.runPythonAsync(await (await fetch('/langs/flax/loader.py')).text() + '\nawait main()')
+let loader = location.origin + location.pathname + 'langs/flax/loader.py';
+pyodide.runPythonAsync(await (await fetch(loader)).text() + '\nawait main()')
 .then (() => DSO.endLoad());
 
 DSO.defineMode("flax", async (code,input,args,output,debug) => {

--- a/langs/flax/loader.py
+++ b/langs/flax/loader.py
@@ -1,12 +1,12 @@
 import sys
 sys.path.append('./')
-from js import fetch
+from js import fetch, location
 
 import os
 os.mkdir("flax")
 
 async def main():
-    files = await fetch("/langs/flax/all.txt")
+    files = await fetch(location.origin + location.pathname + "langs/flax/all.txt")
     files = await files.text()
     for file in files.split('\n')[:-1]:
         text = await fetch('https://raw.githubusercontent.com/pygamer0/flax/master/flax/' + file)

--- a/langs/jelly-fork/jelly-fork.js
+++ b/langs/jelly-fork/jelly-fork.js
@@ -3,7 +3,8 @@ DSO.startLoad();
 
 await pyodide.loadPackage(['sympy'])
 
-pyodide.runPythonAsync(await (await fetch('/langs/jelly-fork/loader.py')).text() + '\nawait main()')
+let loader = location.origin + location.pathname + 'langs/jelly-fork/loader.py';
+pyodide.runPythonAsync(await (await fetch(loader)).text() + '\nawait main()')
 .then (() => DSO.endLoad());
 
 DSO.defineMode("jelly-fork", async (code,input,args,output,debug) => {

--- a/langs/jelly-fork/loader.py
+++ b/langs/jelly-fork/loader.py
@@ -1,12 +1,12 @@
 import sys
 sys.path.append('./')
-from js import fetch
+from js import fetch, location
 
 import os
 os.mkdir("jelly")
 
 async def main():
-    files = await fetch("/langs/jelly/all.txt")
+    files = await fetch(location.origin + location.pathname + "langs/jelly/all.txt")
     files = await files.text()
     for file in files.split('\n')[:-1]:
         text = await fetch('https://raw.githubusercontent.com/cairdcoinheringaahing/jellylanguage/master/jelly/' + file)

--- a/langs/jelly/jelly.js
+++ b/langs/jelly/jelly.js
@@ -1,7 +1,8 @@
 await loadPyodide();
 DSO.startLoad();
 
-pyodide.runPythonAsync(await (await fetch('/langs/jelly/loader.py')).text() + '\nawait main()')
+let loader = location.origin + location.pathname + 'langs/jelly/loader.py';
+pyodide.runPythonAsync(await (await fetch(loader)).text() + '\nawait main()')
 .then (() => DSO.endLoad());
 
 DSO.defineMode("jelly", async (code,input,args,output,debug) => {

--- a/langs/jelly/loader.py
+++ b/langs/jelly/loader.py
@@ -1,12 +1,12 @@
 import sys
 sys.path.append('./')
-from js import fetch
+from js import fetch, location
 
 import os
 os.mkdir("jelly")
 
 async def main():
-    files = await fetch("/langs/jelly/all.txt")
+    files = await fetch(location.origin + location.pathname + "langs/jelly/all.txt")
     files = await files.text()
     for file in files.split('\n')[:-1]:
         text = await fetch('https://raw.githubusercontent.com/DennisMitchell/jellylanguage/master/jelly/' + file)

--- a/langs/pip/loader.py
+++ b/langs/pip/loader.py
@@ -1,9 +1,9 @@
 import sys
 sys.path.append('./')
-from js import fetch
+from js import fetch, location
 
 async def main():
-    files = await fetch("/langs/pip/all.txt")
+    files = await fetch(location.origin + location.pathname + "langs/pip/all.txt")
     files = await files.text()
     for file in files.split('\n')[:-1]:
         text = await fetch('https://raw.githubusercontent.com/dloscutoff/pip/master/' + file)

--- a/langs/pip/pip.js
+++ b/langs/pip/pip.js
@@ -1,7 +1,8 @@
 await loadPyodide();
 DSO.startLoad();
 
-pyodide.runPythonAsync(await (await fetch('/langs/pip/loader.py')).text() + '\nawait main()')
+let loader = location.origin + location.pathname + 'langs/pip/loader.py';
+pyodide.runPythonAsync(await (await fetch(loader)).text() + '\nawait main()')
 .then (() => DSO.endLoad());
 
 DSO.defineMode("pip", async (code,input,args,output,debug) => {


### PR DESCRIPTION
The fetch & load code for languages implemented in Python assumed that DSO would be run from the root of the webserver. This works for `dso.surge.sh`, but not for `xyz.github.io/dso`: for example, the Pip loader would look for `xyz.github.io/langs/pip/all.txt` when it should look for `xyz.github.io/dso/langs/pip/all.txt`. Prepending `location.origin` (`https://xyz.github.io`) and `location.pathname` (`/dso/`) to the file path solves this problem.